### PR TITLE
Optomise P4 queries - Todolist page

### DIFF
--- a/source/P4PlanLib/IP4PlanClient.cs
+++ b/source/P4PlanLib/IP4PlanClient.cs
@@ -12,6 +12,7 @@ public interface IP4PlanClient
     Task<Item?> GetBacklogItem(string id);
     Task<Item?> GetBug(string id);
     Task<List<Item>> Search(string query);
+    Task<List<Item>> GetTodoListAsync(string userID);
     Task<List<Comment>> GetComments(string itemId);
     Task<bool> PostComment(string itemId, string text);
     Task<List<Item>> GetItemChildrenAsync(string backlogEntryId, bool includeCompletedTasks = false);

--- a/source/P4PlanLib/P4PlanDummyClient.cs
+++ b/source/P4PlanLib/P4PlanDummyClient.cs
@@ -716,6 +716,19 @@ namespace P4PlanLib
             return Task.FromResult(results);
         }
 
+        public Task<List<Item>> GetTodoListAsync(string userID)
+        {
+            // Return items assigned to the connected dev user (simulating authenticated user context)
+            // In production, the backend filters by authenticated user automatically
+            var userItems = _items.Values
+                .Where(item => item.AssignedTo != null &&
+                               item.AssignedTo.Any(assigned => assigned.User.Name == _connectedUserName))
+                .Take(20)
+                .ToList();
+
+            return Task.FromResult(userItems);
+        }
+
         public Task<IEnumerable<string>> GetPrioritiesAsync()
         {
             var order = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)

--- a/source/PlanIt/Pages/Milestone.razor
+++ b/source/PlanIt/Pages/Milestone.razor
@@ -27,7 +27,7 @@ else if (!loaded)
 }
 else
 {
-    <FilterToolbar TModel="Item" TargetItems="rankedList" OnApplyFilter="HandleFilterApplied" />
+    <FilterToolbar TModel="Item" TargetItems="filterToolbarList" OnApplyFilter="HandleFilterApplied" />
     <MudDataGrid Items="rankedList" Hover="true" Striped="true" Dense="true" Bordered="true" FilterMode="DataGridFilterMode.Simple" FilterCaseSensitivity="DataGridFilterCaseSensitivity.CaseInsensitive" SortLabel="Sort by">
         <ColGroup>
             <col style="width: 50px;" />
@@ -66,6 +66,7 @@ else
 @code {
     private ObservableCollection<P4PlanLib.Model.Item>? dashboardItems { get; set; }
     private ObservableCollection<P4PlanLib.Model.Item>? rankedList { get; set; }
+    private List<P4PlanLib.Model.Item>? filterToolbarList { get; set; }
     private bool loaded { get; set; } = false;
 
     private P4PlanLib.IP4PlanClient? p4PlanClient;
@@ -105,6 +106,7 @@ else
             {
                 rankedList[i].Rank = i + 1;
             }
+            filterToolbarList = new List<P4PlanLib.Model.Item>(rankedList);
 
             loaded = true;
             StateHasChanged();
@@ -126,5 +128,6 @@ else
                 rankedList?.Add(item);
             }
         }
+        StateHasChanged();
     }
 }

--- a/source/PlanIt/Pages/Todolist.razor
+++ b/source/PlanIt/Pages/Todolist.razor
@@ -74,7 +74,6 @@ else
     {
         if (HttpContextAccessor.HttpContext?.User.Identity?.IsAuthenticated ?? false && !loaded)
         {
-            var displayName = HttpContextAccessor.HttpContext?.User.Claims.First(c => c.Type == ClaimTypes.Name).Value;
             var email = HttpContextAccessor.HttpContext?.User.Claims.First(c => c.Type == ClaimTypes.Email).Value;
             var p4PlanClient = P4PlanClientProvider.GetP4PlanClient(email);
             if (p4PlanClient is null)
@@ -82,21 +81,20 @@ else
                 Navigation.NavigateTo("/");
                 return;
             }
+            var allItems = await p4PlanClient.GetTodoListAsync("");
 
-            var comparer = new P4PlanLib.ItemComparer();
+            // Categorize items by type for ranking
+            myOpenShowstoppers = allItems.Where(i => TypeString(i) == "Showstopper").ToList();
+            mySprintItems = allItems.Where(i => TypeString(i) == "Sprint").ToList();
+            myOpenBugs = allItems.Where(i => TypeString(i) == "Bug").ToList();
+            myBacklog = allItems.Where(i => TypeString(i) == "Backlog").ToList();
 
-            myOpenBugs = await p4PlanClient.Search($"\"Item type\"=bug and Severity >\"Severity B\" and \"Assigned to\":\"{displayName}\"");
-            myOpenShowstoppers = await p4PlanClient.Search($"\"Item type\"=bug and Severity <=\"Severity B\" and \"Assigned to\":\"{displayName}\"");
-            mySprintItems = await p4PlanClient.Search($"\"Item type\"=\"backlog item\" and \"Assigned to\":\"{displayName}\" and \"Committed to\":\"{ProjectDetailsService.CurrentSprint}\"");
-            myBacklog = await p4PlanClient.Search($"\"Item type\"=\"backlog item\" and \"Assign tag\":\"{displayName}\"");
-            myBacklog = myBacklog.Except(mySprintItems, comparer).ToList();
-
+            // Build ranked list: Showstoppers > Sprint items > Open bugs > Backlog
             rankedList = new List<P4PlanLib.Model.Item>();
             rankedList.AddRange(myOpenShowstoppers);
-            rankedList.AddRange(mySprintItems.Except(rankedList, comparer));
-            rankedList.AddRange(myOpenBugs.Except(rankedList, comparer));
-            rankedList.AddRange(myBacklog.Except(rankedList, comparer));
-
+            rankedList.AddRange(mySprintItems);
+            rankedList.AddRange(myOpenBugs);
+            rankedList.AddRange(myBacklog);
             for(var i = 0 ; i < rankedList.Count ; i++)
             {
                 rankedList[i].Rank = i + 1;

--- a/source/PlanIt/Pages/Todolist.razor
+++ b/source/PlanIt/Pages/Todolist.razor
@@ -23,7 +23,7 @@
 else
 {
     <MudText>Ordered by Showstoppers > Sprint tasks > Open bugs not in sprint > Backlog</MudText>
-    <FilterToolbar TModel="Item" TargetItems="rankedList" OnApplyFilter="HandleFilterApplied" />
+    <FilterToolbar TModel="Item" TargetItems="filterToolbarList" OnApplyFilter="HandleFilterApplied" />
 
     <MudTable Items="rankedList" Hover="true" Striped="true" Dense="true" Bordered="true" SortLabel="Sort by">
         <ColGroup>
@@ -67,6 +67,7 @@ else
     private List<P4PlanLib.Model.Item>? myOpenShowstoppers { get; set; }
     private List<P4PlanLib.Model.Item>? myBacklog { get; set; }
     private List<P4PlanLib.Model.Item>? rankedList { get; set; }
+    private List<P4PlanLib.Model.Item>? filterToolbarList { get; set; }
     private bool loaded { get; set; } = false;
     private bool showEmptyCategories { get; set; }
 
@@ -99,7 +100,7 @@ else
             {
                 rankedList[i].Rank = i + 1;
             }
-
+        filterToolbarList = new List<P4PlanLib.Model.Item>(rankedList);
             loaded = true;
             StateHasChanged();
         }
@@ -141,6 +142,7 @@ else
                 rankedList?.Add(item);
             }
         }
+        StateHasChanged();
     }
 
     private string TypeString(Item i)


### PR DESCRIPTION
This refactored codebase to optomise the P4 Plan queries used in the **Todolist** feature by introducing a dedicated GetTodoListAsync() method that fetches all relevant items in a single GraphQL query instead of making multiple separate queries related to issue #7 

### Key Changes
- New Interface Method (IP4PlanClient.cs)
   Added `Task<List<Item>> GetTodoListAsync(string userID)` to the interface
- Implementation in P4PlanClient (P4PlanClient.cs)
   New `GetTodoListAsync()` method: Executes a single optimised GraphQL query 
- New `ParseItemFromGraphQL()` helper method: Parses GraphQL responses and correctly sets the item type based on the __typename field

@NQ-Aliandre I have no idea how your backend API is set up. To complete this I used a my local GraphQL server that I developed using TypeScript and faker.js , using the official GraphQL documentations  

<img width="1580" height="809" alt="image" src="https://github.com/user-attachments/assets/85070972-9926-4edd-9a5e-9818343063fe" />
